### PR TITLE
feat(order): 주문 상태/결제/배송 카드 컴포넌트 추가 

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@/*": ["src/*"]
     },
+    "checkJs": true,
     "jsx": "react-jsx"
   },
   "include": ["src"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react-study",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.74.3",
         "axios": "^1.8.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1307,6 +1308,30 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.74.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.74.4.tgz",
+      "integrity": "sha512-YuG0A0+3i9b2Gfo9fkmNnkUWh5+5cFhWBN0pJAHkHilTx6A0nv8kepkk4T4GRt4e5ahbtFj2eTtkiPcVU1xO4A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.74.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.74.4.tgz",
+      "integrity": "sha512-mAbxw60d4ffQ4qmRYfkO1xzRBPUEf/72Dgo3qqea0J66nIKuDTLEqQt0ku++SDFlMGMnB6uKDnEG1xD/TDse4Q==",
+      "dependencies": {
+        "@tanstack/query-core": "5.74.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.74.3",
     "axios": "^1.8.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,10 @@
+import OrderPage from "@/pages/OrderPage";
+
 import ProductPage from "@/pages/ProductPage";
 
 const App = () => {
-  <ProductPage />;
+  // <OrderPage />;
+  return <OrderPage />;
 };
 
 export default App;

--- a/src/api/apiClient.js
+++ b/src/api/apiClient.js
@@ -1,0 +1,8 @@
+import axios from "axios";
+const apiClient = axios.create({
+  baseURL: "https://dummyjson.com",
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+export default apiClient;

--- a/src/api/productsAPI.js
+++ b/src/api/productsAPI.js
@@ -1,0 +1,12 @@
+import apiClient from "@/api/apiClient";
+
+export const fetchProducts = async () => {
+  const { data } = await apiClient.get("/products");
+  const refined = data.products.map((product) => ({
+    id: product.id,
+    name: product.title,
+    price: product.price,
+    thumbnail: product.thumbnail,
+  }));
+  return refined;
+};

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,16 @@
+const Card = ({ header, data = [], footer }) => (
+  <div className="Card">
+    {header && <header>{header}</header>}
+    <main>
+      {data.map(({ term, description }) => (
+        <dl key={term}>
+          <dt>{term}</dt>
+          <dd>{description}</dd>
+        </dl>
+      ))}
+    </main>
+    {footer && <footer>{footer}</footer>}
+  </div>
+);
+
+export default Card;

--- a/src/components/Title.jsx
+++ b/src/components/Title.jsx
@@ -1,5 +1,5 @@
 const Title = ({ children }) => {
-  <h1>{children}</h1>;
+  return <h1>{children}</h1>;
 };
 
 export default Title;

--- a/src/hooks/useProducts.js
+++ b/src/hooks/useProducts.js
@@ -1,0 +1,12 @@
+import { fetchProducts } from "@/api/productsAPI";
+import { useQuery } from "@tanstack/react-query";
+
+const useProducts = () => {
+  return useQuery({
+    queryKey: ["products"],
+    queryFn: fetchProducts, // API 호출
+    // key값에 데이터가 캐싱돼있음 -> 그럼 서버말고 자동으로 저장되있던 key 값가져옴
+  });
+};
+
+export default useProducts;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,23 @@
-import App from "@/App";
-import React from "react";
-import ReactDOM from "react-dom/client";
+// import App from "@/App";
+// import React from "react";
+// import ReactDOM from "react-dom/client";
 
+// const root = ReactDOM.createRoot(document.getElementById("root"));
+
+// root.render(
+//   <React.StrictMode>
+//     <App />
+//   </React.StrictMode>
+// );
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "@/App";
+
+const queryClient = new QueryClient();
 const root = ReactDOM.createRoot(document.getElementById("root"));
 
 root.render(
-  <React.StrictMode>
+  <QueryClientProvider client={queryClient}>
     <App />
-  </React.StrictMode>
+  </QueryClientProvider>
 );

--- a/src/pages/OrderPage/OrderDeliveryCard.jsx
+++ b/src/pages/OrderPage/OrderDeliveryCard.jsx
@@ -1,0 +1,18 @@
+import Card from "@/components/Card";
+
+const OrderDeliveryCard = ({ order }) => {
+  const { deliveryAddress, deliveryContact, messageToShop, messageToRider } = order;
+
+  return (
+    <Card
+      data={[
+        { term: "배달주소", description: deliveryAddress },
+        { term: "전화번호", description: deliveryContact },
+        { term: "가게사장님께", description: messageToShop },
+        { term: "라이더님께", description: messageToRider },
+      ]}
+    />
+  );
+};
+
+export default OrderDeliveryCard;

--- a/src/pages/OrderPage/OrderPaymentCard.jsx
+++ b/src/pages/OrderPage/OrderPaymentCard.jsx
@@ -1,0 +1,24 @@
+import Card from "@/components/Card";
+
+const OrderPaymentCard = ({ order }) => {
+  const { totalPrice, paymentMethod, productPrice, deliveryPrice, discountPrice } = order;
+
+  return (
+    <Card
+      header={
+        <>
+          총 결제금액: {totalPrice}원
+          <br />
+          결제 방법: {paymentMethod}
+        </>
+      }
+      data={[
+        { term: "메뉴가격", description: `${productPrice}원` },
+        { term: "배달료", description: `${deliveryPrice}원` },
+        { term: "할인금액", description: `${discountPrice}원` },
+      ]}
+    />
+  );
+};
+
+export default OrderPaymentCard;

--- a/src/pages/OrderPage/OrderStatusCard.jsx
+++ b/src/pages/OrderPage/OrderStatusCard.jsx
@@ -1,0 +1,30 @@
+import Button from "@/components/Button";
+import Card from "@/components/Card";
+
+const OrderStatusCard = ({ order }) => {
+  const { status, name, orderDate, id } = order;
+
+  return (
+    <Card
+      header={
+        <>
+          <strong>{status}</strong>
+          <br />
+          {name}
+        </>
+      }
+      data={[
+        { term: "주문일시", description: orderDate },
+        { term: "주문번호", description: id },
+      ]}
+      footer={
+        <>
+          <Button>전화</Button>
+          <Button>가게보기</Button>
+        </>
+      }
+    />
+  );
+};
+
+export default OrderStatusCard;

--- a/src/pages/OrderPage/index.jsx
+++ b/src/pages/OrderPage/index.jsx
@@ -2,6 +2,7 @@ import Navbar from "@/components/Navbar";
 import OrderStatusCard from "@/pages/OrderPage/OrderStatusCard";
 import Page from "@/components/Page";
 import Title from "@/components/Title";
+import OrderDeliveryCard from "@/pages/OrderPage/OrderDeliveryCard";
 
 const fakeOrder = {
   id: "CACDA420",
@@ -24,6 +25,7 @@ const OrderPage = () => (
   <div className="OrderPage">
     <Page header={<Title>주문내역</Title>} footer={<Navbar />}>
       <OrderStatusCard order={fakeOrder} />
+      <OrderDeliveryCard order={fakeOrder} />
     </Page>
   </div>
 );

--- a/src/pages/OrderPage/index.jsx
+++ b/src/pages/OrderPage/index.jsx
@@ -3,6 +3,7 @@ import OrderStatusCard from "@/pages/OrderPage/OrderStatusCard";
 import Page from "@/components/Page";
 import Title from "@/components/Title";
 import OrderDeliveryCard from "@/pages/OrderPage/OrderDeliveryCard";
+import OrderPaymentCard from "@/pages/OrderPage/OrderPaymentCard";
 
 const fakeOrder = {
   id: "CACDA420",
@@ -25,6 +26,7 @@ const OrderPage = () => (
   <div className="OrderPage">
     <Page header={<Title>주문내역</Title>} footer={<Navbar />}>
       <OrderStatusCard order={fakeOrder} />
+      <OrderPaymentCard order={fakeOrder} />
       <OrderDeliveryCard order={fakeOrder} />
     </Page>
   </div>

--- a/src/pages/OrderPage/index.jsx
+++ b/src/pages/OrderPage/index.jsx
@@ -1,0 +1,13 @@
+import Navbar from "@/components/Navbar";
+import Page from "@/components/Page";
+import Title from "@/components/Title";
+
+const OrderPage = () => (
+  <div className="OrderPage">
+    <Page header={<Title>주문내역</Title>} footer={<Navbar />}>
+      여기에 내용
+    </Page>
+  </div>
+);
+
+export default OrderPage;

--- a/src/pages/OrderPage/index.jsx
+++ b/src/pages/OrderPage/index.jsx
@@ -1,11 +1,29 @@
 import Navbar from "@/components/Navbar";
+import OrderStatusCard from "@/pages/OrderPage/OrderStatusCard";
 import Page from "@/components/Page";
 import Title from "@/components/Title";
+
+const fakeOrder = {
+  id: "CACDA420",
+  orderDate: "2023. 5. 13. 오후 1:37:51",
+  status: "음식 준비중",
+  name: "짜장면",
+  totalPrice: 7000,
+  paymentMethod: "마이페이",
+  productPrice: 6000,
+  deliveryPrice: 3000,
+  discountPrice: 2000,
+  deliveryAddress: "서울특별시 송파구 잠실동 1번지",
+  deliveryContact: "010-1111-2222",
+  messageToShop: "포크는 주지 마세요",
+  messageToRider: "안전하게 오세요",
+  position: [30, 30],
+};
 
 const OrderPage = () => (
   <div className="OrderPage">
     <Page header={<Title>주문내역</Title>} footer={<Navbar />}>
-      여기에 내용
+      <OrderStatusCard order={fakeOrder} />
     </Page>
   </div>
 );


### PR DESCRIPTION
## 구현한 내용
- [x] `OrderPage` 화면은 컴포넌트 재사용해서 구성
  - `Page` 컴포넌트를 사용해 상단, 중앙, 하단 구조 적용
  - `Title`: "주문내역" 텍스트 표시
  - `Navbar`: 하단에 고정, 주문내역 메뉴 강조
- [x] `Card` 컴포넌트 제작 (상단/중앙/하단 조건부 렌더링)
- [x] 세부 카드 3종 구현
  - `OrderStatusCard`: 주문 상태 카드
    - 상단: 주문상태, 메뉴명
    - 중앙: 주문일시, 주문번호
    - 하단: 전화 버튼, 가게 보기 버튼
  - `OrderPaymentCard`: 결제 정보 카드
    - 상단: 결제 금액, 결제 수단
    - 중앙: 메뉴 가격, 배달료, 할인 금액
  - `OrderDeliveryCard`: 배송 정보 카드
    - 중앙: 배달 주소, 전화번호, 전달 메시지

